### PR TITLE
Fix concurrency bug

### DIFF
--- a/CentralHub.Api.Tests/RoomControllerTests.cs
+++ b/CentralHub.Api.Tests/RoomControllerTests.cs
@@ -1,6 +1,7 @@
 using CentralHub.Api.Controllers;
 using CentralHub.Api.Model;
 using CentralHub.Api.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace CentralHub.Api.Tests;
 
@@ -13,7 +14,7 @@ public class RoomControllerTests
     public void Setup()
     {
         _roomRepository = new RoomRepository();
-        _roomController = new RoomController(_roomRepository);
+        _roomController = new RoomController(NullLogger<RoomController>.Instance, _roomRepository);
     }
 
     [Test]

--- a/CentralHub.Api/Controllers/RoomController.cs
+++ b/CentralHub.Api/Controllers/RoomController.cs
@@ -8,10 +8,12 @@ namespace CentralHub.Api.Controllers;
 [Route("/room")]
 public class RoomController : ControllerBase
 {
+    private readonly ILogger<RoomController> _logger;
     private readonly IRoomRepository _roomRepository;
 
-    public RoomController(IRoomRepository roomRepository)
+    public RoomController(ILogger<RoomController> logger, IRoomRepository roomRepository)
     {
+        _logger = logger;
         _roomRepository = roomRepository;
     }
 
@@ -34,7 +36,8 @@ public class RoomController : ControllerBase
         var room = await _roomRepository.GetRoomByIdAsync(id, cancellationToken);
         if (room == null)
         {
-            throw new InvalidOperationException("Room not found");
+            _logger.LogError("Room did not exist!");
+            return;
         }
         await _roomRepository.RemoveRoomAsync(room, cancellationToken);
     }

--- a/CentralHub.Api/Program.cs
+++ b/CentralHub.Api/Program.cs
@@ -1,7 +1,5 @@
 using CentralHub.Api.DbContexts;
-using CentralHub.Api.Model;
 using CentralHub.Api.Services;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 
 // Use state directory given by systemd
@@ -21,23 +19,22 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddEntityFrameworkSqlite();
 
+var dbPath = Path.Combine(stateDirectory, "data.db");
+
 #if DEBUG
-var id = $"{Guid.NewGuid().ToString()}.db";
-
-var sqliteStringBuilder = new SqliteConnectionStringBuilder()
+try
 {
-    DataSource = id,
-    Mode = SqliteOpenMode.Memory,
-    Cache = SqliteCacheMode.Shared
-};
-
-var connectionString = sqliteStringBuilder.ToString();
-#else
-var connectionString = $"Data Source={Path.Combine(stateDirectory, "data.db")}";
+    File.Delete(dbPath);
+}
+catch
+{
+    // Ignore
+}
 #endif
+var connectionString = $"Data Source={dbPath}";
 
-builder.Services.AddDbContext<ApplicationDbContext>(options => options.UseSqlite(connectionString), ServiceLifetime.Singleton);
-builder.Services.AddSingleton<IRoomRepository, RoomRepository>();
+builder.Services.AddDbContext<ApplicationDbContext>(options => options.UseSqlite(connectionString));
+builder.Services.AddScoped<IRoomRepository, RoomRepository>();
 
 var app = builder.Build();
 
@@ -46,14 +43,6 @@ if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
-
-    // Insert dummy trackers
-    var roomRepository = app.Services.GetRequiredService<IRoomRepository>();
-    var room = new Room("Test Room 1", "Test Room");
-    roomRepository.AddRoomAsync(room, default).GetAwaiter().GetResult();
-    roomRepository.AddTrackerAsync(new Tracker("Test Tracker 1", "Test Tracker", "AA:BB:CC:DD:EE:FF", room), default).GetAwaiter().GetResult();
-    roomRepository.AddTrackerAsync(new Tracker("Test Tracker 2", "Test Tracker", "FF:EE:DD:CC:BB:AA", room), default).GetAwaiter().GetResult();
-    roomRepository.AddTrackerAsync(new Tracker("Test Tracker 3", "Test Tracker", "00:11:22:33:44:55", room), default).GetAwaiter().GetResult();
 }
 
 

--- a/CentralHub.Api/Services/RoomRepository.cs
+++ b/CentralHub.Api/Services/RoomRepository.cs
@@ -6,6 +6,7 @@ namespace CentralHub.Api.Services;
 
 internal sealed class RoomRepository : IRoomRepository
 {
+    private static volatile bool _hasAddedTrackers = false;
     private readonly ApplicationDbContext _applicationDbContext;
 
     public RoomRepository(ApplicationDbContext applicationDbContext)
@@ -13,6 +14,20 @@ internal sealed class RoomRepository : IRoomRepository
         _applicationDbContext = applicationDbContext;
         _applicationDbContext.Database.OpenConnection();
         _applicationDbContext.Database.EnsureCreated();
+
+#if DEBUG
+        if (_hasAddedTrackers)
+        {
+            return;
+        }
+        // Insert dummy trackers
+        var room = new Room("Test Room 1", "Test Room");
+        AddRoomAsync(room, default).GetAwaiter().GetResult();
+        AddTrackerAsync(new Tracker("Test Tracker 1", "Test Tracker", "AA:BB:CC:DD:EE:FF", room), default).GetAwaiter().GetResult();
+        AddTrackerAsync(new Tracker("Test Tracker 2", "Test Tracker", "FF:EE:DD:CC:BB:AA", room), default).GetAwaiter().GetResult();
+        AddTrackerAsync(new Tracker("Test Tracker 3", "Test Tracker", "00:11:22:33:44:55", room), default).GetAwaiter().GetResult();
+        _hasAddedTrackers = true;
+#endif
     }
 
     public async Task AddRoomAsync(Room room, CancellationToken cancellationToken)


### PR DESCRIPTION
DbContexts does not like being accessed from multiple threads. ApplicationDbContext was accessed from multiple threads because we added it as a singleton.
Now it is changed to being scoped, so we get an instance of ApplicationDbContext for each request.
IRoomService is now also scoped for each request.