### PR TITLE
Keep track of unregistered trackers

### DIFF
--- a/CentralHub.Api.Model/Responses/Tracker/GetUnregisteredTrackersResponse.cs
+++ b/CentralHub.Api.Model/Responses/Tracker/GetUnregisteredTrackersResponse.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace CentralHub.Api.Model.Responses.Tracker;
+
+public sealed class GetUnregisteredTrackersResponse
+{
+    public IEnumerable<UnregisteredTracker> UnregisteredTrackers { get; }
+
+    [JsonConstructor]
+    public GetUnregisteredTrackersResponse(IEnumerable<UnregisteredTracker> unregisteredTrackers)
+    {
+        UnregisteredTrackers = unregisteredTrackers;
+    }
+}

--- a/CentralHub.Api.Model/Responses/Tracker/UnregisteredTracker.cs
+++ b/CentralHub.Api.Model/Responses/Tracker/UnregisteredTracker.cs
@@ -1,0 +1,13 @@
+namespace CentralHub.Api.Model.Responses.Tracker;
+
+public sealed class UnregisteredTracker
+{
+    public string WifiMacAddress { get; }
+    public string BluetoothMacAddress { get; }
+
+    public UnregisteredTracker(string wifiMacAddress, string bluetoothMacAddress)
+    {
+        WifiMacAddress = wifiMacAddress;
+        BluetoothMacAddress = bluetoothMacAddress;
+    }
+}

--- a/CentralHub.Api.Tests/TrackersControllerTests.cs
+++ b/CentralHub.Api.Tests/TrackersControllerTests.cs
@@ -134,7 +134,10 @@ public class TrackersControllerTests
 
     private sealed class TrackerRepository : ITrackerRepository
     {
+        private readonly List<UnregisteredTrackerDto> _unregisteredTrackers = new List<UnregisteredTrackerDto>();
+
         private int _nextId = 0;
+
 
         public RoomDto RoomDto { get; }
 
@@ -196,6 +199,22 @@ public class TrackersControllerTests
         {
             return Task.FromResult(RoomDto.Trackers.SingleOrDefault(t =>
                 t.WifiMacAddress == wifiMacAddress && t.BluetoothMacAddress == bluetoothMacAddress));
+        }
+
+        public Task<IEnumerable<UnregisteredTrackerDto>> GetUnregisteredTrackers(CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IEnumerable<UnregisteredTrackerDto>>(_unregisteredTrackers.ToArray());
+        }
+
+        public Task AddUnregisteredTracker(string wifiMacAddress, string bluetoothMacAddress, CancellationToken cancellationToken)
+        {
+            _unregisteredTrackers.Add(
+                new UnregisteredTrackerDto
+                {
+                    WifiMacAddress = wifiMacAddress,
+                    BluetoothMacAddress = bluetoothMacAddress,
+                });
+            return Task.CompletedTask;
         }
     }
 }

--- a/CentralHub.Api/Controllers/TrackerController.cs
+++ b/CentralHub.Api/Controllers/TrackerController.cs
@@ -95,9 +95,19 @@ public class TrackerController : ControllerBase
 
         if (possibleTracker == null)
         {
+            await _trackerRepository.AddUnregisteredTracker(wifiMacAddress, bluetoothMacAddress, cancellationToken);
             return GetTrackerRegistrationInfoResponse.CreateUnregistered();
         }
 
         return GetTrackerRegistrationInfoResponse.CreateRegistered(possibleTracker.TrackerDtoId);
+    }
+
+    [HttpGet("registration/unregistered")]
+    public async Task<GetUnregisteredTrackersResponse> GetUnregisteredTrackers(CancellationToken cancellationToken)
+    {
+        var unregisteredTrackers = await _trackerRepository.GetUnregisteredTrackers(cancellationToken);
+
+        return new GetUnregisteredTrackersResponse(
+            unregisteredTrackers.Select(t => new UnregisteredTracker(t.WifiMacAddress, t.BluetoothMacAddress)));
     }
 }

--- a/CentralHub.Api/Dtos/UnregisteredTrackerDto.cs
+++ b/CentralHub.Api/Dtos/UnregisteredTrackerDto.cs
@@ -1,0 +1,8 @@
+namespace CentralHub.Api.Dtos;
+
+public class UnregisteredTrackerDto
+{
+    public required string WifiMacAddress { get; set; }
+
+    public required string BluetoothMacAddress { get; set; }
+}

--- a/CentralHub.Api/Services/ITrackerRepository.cs
+++ b/CentralHub.Api/Services/ITrackerRepository.cs
@@ -16,4 +16,8 @@ public interface ITrackerRepository
 
     Task<TrackerDto?> GetTrackerByMacAddresses(string wifiMacAddress, string bluetoothMacAddress,
         CancellationToken cancellationToken);
+
+    Task<IEnumerable<UnregisteredTrackerDto>> GetUnregisteredTrackers(CancellationToken cancellationToken);
+
+    Task AddUnregisteredTracker(string wifiMacAddress, string bluetoothMacAddress, CancellationToken cancellationToken);
 }

--- a/CentralHub.WebUI/Data/RoomService.cs
+++ b/CentralHub.WebUI/Data/RoomService.cs
@@ -53,24 +53,4 @@ public sealed class RoomService
         return rooms;
     }
 
-    public async Task<Tracker[]> GetTrackersAsync(Room room, CancellationToken cancellationToken)
-    {
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"http://localhost:8081/tracker/all?roomId={room.RoomId}");
-        request.Headers.Add("Accept", "application/json");
-        request.Headers.Add("User-Agent", "CentralHub.WebUI");
-
-        var client = _clientFactory.CreateClient();
-
-        var response = await client.SendAsync(request, cancellationToken);
-        var trackers = await response.Content.ReadFromJsonAsync<GetTrackersResponse>(cancellationToken: cancellationToken);
-
-        if (trackers == null || !trackers.Success)
-        {
-            throw new InvalidOperationException("Shit brokey");
-        }
-
-        return trackers.Trackers.ToArray();
-    }
 }

--- a/CentralHub.WebUI/Data/TrackerService.cs
+++ b/CentralHub.WebUI/Data/TrackerService.cs
@@ -1,0 +1,57 @@
+using System.Collections.Immutable;
+using CentralHub.Api.Model.Responses.Room;
+using CentralHub.Api.Model.Responses.Tracker;
+
+namespace CentralHub.WebUI.Data;
+
+public sealed class TrackerService
+{
+    private readonly IHttpClientFactory _clientFactory;
+
+    public TrackerService(IHttpClientFactory clientFactory)
+    {
+        _clientFactory = clientFactory;
+    }
+
+    public async Task<Tracker[]> GetTrackersAsync(Room room, CancellationToken cancellationToken)
+    {
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"http://localhost:8081/tracker/all?roomId={room.RoomId}");
+        request.Headers.Add("Accept", "application/json");
+        request.Headers.Add("User-Agent", "CentralHub.WebUI");
+
+        var client = _clientFactory.CreateClient();
+
+        var response = await client.SendAsync(request, cancellationToken);
+        var trackers = await response.Content.ReadFromJsonAsync<GetTrackersResponse>(cancellationToken: cancellationToken);
+
+        if (trackers == null || !trackers.Success)
+        {
+            throw new InvalidOperationException("Shit brokey");
+        }
+
+        return trackers.Trackers.ToArray();
+    }
+
+    public async Task<UnregisteredTracker[]> GetUnregisteredTrackersAsync(CancellationToken cancellationToken)
+    {
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"http://localhost:8081/tracker/registration/unregistered");
+        request.Headers.Add("Accept", "application/json");
+        request.Headers.Add("User-Agent", "CentralHub.WebUI");
+
+        var client = _clientFactory.CreateClient();
+
+        var response = await client.SendAsync(request, cancellationToken);
+        var unregisteredTrackers = await response.Content.ReadFromJsonAsync<GetUnregisteredTrackersResponse>(cancellationToken: cancellationToken);
+
+        if (unregisteredTrackers == null)
+        {
+            throw new InvalidOperationException("Shit brokey");
+        }
+
+        return unregisteredTrackers.UnregisteredTrackers.ToArray();
+    }
+}

--- a/CentralHub.WebUI/Pages/Rooms.razor
+++ b/CentralHub.WebUI/Pages/Rooms.razor
@@ -4,6 +4,7 @@
 @using CentralHub.Api.Model.Responses.Room
 @implements IDisposable
 @inject RoomService RoomService
+@inject TrackerService TrackerService
 
 <PageTitle>Rooms</PageTitle>
 
@@ -70,7 +71,7 @@ else
 
     private async Task<int> GetTrackerCountAsync(Room room)
     {
-        var trackers = await RoomService.GetTrackersAsync(room, _cancellationTokenSource.Token);
+        var trackers = await TrackerService.GetTrackersAsync(room, _cancellationTokenSource.Token);
 
         return trackers.Length;
     }

--- a/CentralHub.WebUI/Pages/UnregisteredTrackers.razor
+++ b/CentralHub.WebUI/Pages/UnregisteredTrackers.razor
@@ -1,0 +1,55 @@
+@page "/unregisteredtrackers"
+@using CentralHub.WebUI.Data
+@using CentralHub.Api.Model.Responses.Room
+@using CentralHub.Api.Model.Responses.Tracker
+@implements IDisposable
+@inject TrackerService TrackerService
+
+<PageTitle>Unregistered Trackers</PageTitle>
+
+<h1>Unregistered Trackers</h1>
+
+<p>This component demonstrates fetching data from a service.</p>
+
+@if (_unregisteredTrackers == null)
+{
+    <p>
+        <em>Loading...</em>
+    </p>
+}
+else
+{
+    <table class="table">
+        <thead>
+        <tr>
+            <th scope="col">Wifi Mac Address</th>
+            <th scope="col">Bluetooth Mac Address</th>
+        </tr>
+        </thead>
+        <tbody>
+        @foreach (var unregisteredTracker in _unregisteredTrackers)
+        {
+            <tr>
+                <td>@unregisteredTracker.WifiMacAddress</td>
+                <td>@unregisteredTracker.BluetoothMacAddress</td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+
+@code {
+    private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+    private List<UnregisteredTracker>? _unregisteredTrackers;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _unregisteredTrackers = (await TrackerService.GetUnregisteredTrackersAsync(_cancellationTokenSource.Token)).ToList();
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Cancel();
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/CentralHub.WebUI/Program.cs
+++ b/CentralHub.WebUI/Program.cs
@@ -19,6 +19,7 @@ internal static class Program
         builder.Services.AddRazorPages();
         builder.Services.AddServerSideBlazor();
         builder.Services.AddSingleton<RoomService>();
+        builder.Services.AddSingleton<TrackerService>();
         builder.Services.AddHttpClient();
 
         var app = builder.Build();

--- a/CentralHub.WebUI/Shared/NavMenu.razor
+++ b/CentralHub.WebUI/Shared/NavMenu.razor
@@ -19,6 +19,11 @@
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Rooms
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="unregisteredtrackers">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Unregistered Trackers
+            </NavLink>
+        </div>
     </nav>
 </div>
 


### PR DESCRIPTION
Add an endpoint to get unregistered trackers.
Remove an unregistered tracker from the list when it has been added with /tracker/add.