### PR TITLE
Filter trackers from measurements and fixed empty aggregated 

### DIFF
--- a/CentralHub.Api.Model/Responses/Measurements/AddMeasurementResponse.cs
+++ b/CentralHub.Api.Model/Responses/Measurements/AddMeasurementResponse.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace CentralHub.Api.Model.Responses.AggregatedMeasurements;
+
+public sealed class AddMeasurementResponse
+{
+    [JsonConstructor]
+    public AddMeasurementResponse(bool success)
+    {
+        Success = success;
+    }
+
+    public bool Success { get; }
+
+    public static AddMeasurementResponse CreateUnsuccessful()
+    {
+        return new AddMeasurementResponse(false);
+    }
+
+    public static AddMeasurementResponse CreateSuccessful()
+    {
+        return new AddMeasurementResponse(true);
+    }
+}

--- a/CentralHub.Api.Model/Responses/Measurements/AddMeasurementResponse.cs
+++ b/CentralHub.Api.Model/Responses/Measurements/AddMeasurementResponse.cs
@@ -2,23 +2,23 @@ using System.Text.Json.Serialization;
 
 namespace CentralHub.Api.Model.Responses.AggregatedMeasurements;
 
-public sealed class AddMeasurementResponse
+public sealed class AddMeasurementsResponse
 {
     [JsonConstructor]
-    public AddMeasurementResponse(bool success)
+    public AddMeasurementsResponse(bool success)
     {
         Success = success;
     }
 
     public bool Success { get; }
 
-    public static AddMeasurementResponse CreateUnsuccessful()
+    public static AddMeasurementsResponse CreateUnsuccessful()
     {
-        return new AddMeasurementResponse(false);
+        return new AddMeasurementsResponse(false);
     }
 
-    public static AddMeasurementResponse CreateSuccessful()
+    public static AddMeasurementsResponse CreateSuccessful()
     {
-        return new AddMeasurementResponse(true);
+        return new AddMeasurementsResponse(true);
     }
 }

--- a/CentralHub.Api.Tests/MeasurementControllerTests.cs
+++ b/CentralHub.Api.Tests/MeasurementControllerTests.cs
@@ -70,7 +70,7 @@ public class MeasurementControllerTests
 
         var addMeasurementsRequest = new AddMeasurementsRequest(_trackerId, measurements);
         await _measurementController.AddMeasurements(addMeasurementsRequest, default);
-        var addedMeasurements = (await _aggregatedMeasurementRepository.GetTrackerMeasurementGroupsAsync(default))[_trackerId][0].Measurements;
+        var addedMeasurements = (await _aggregatedMeasurementRepository.GetRoomMeasurementGroupsAsync(default))[_trackerId][0].Measurements;
 
         Assert.That(addedMeasurements, Has.Count.EqualTo(measurements.Length));
         Assert.That(addedMeasurements, Does.Contain(measurements[0]));
@@ -78,7 +78,7 @@ public class MeasurementControllerTests
     }
 
     [Test]
-    public async Task TestAddTrackerAsMeasurements()
+    public async Task TrackersFilteredFromMeasurements()
     {
         var measurements = new Measurement[] {
             new Measurement("11:22:33:44:55:66", Measurement.Protocol.Bluetooth, 10),
@@ -87,7 +87,7 @@ public class MeasurementControllerTests
 
         var addMeasurementsRequest = new AddMeasurementsRequest(_trackerId, measurements);
         await _measurementController.AddMeasurements(addMeasurementsRequest, default);
-        var addedMeasurements = (await _aggregatedMeasurementRepository.GetTrackerMeasurementGroupsAsync(default))[_trackerId][0].Measurements;
+        var addedMeasurements = (await _aggregatedMeasurementRepository.GetRoomMeasurementGroupsAsync(default))[_trackerId][0].Measurements;
 
         Assert.That(addedMeasurements, Has.Count.EqualTo(0));
     }

--- a/CentralHub.Api.Tests/MeasurementControllerTests.cs
+++ b/CentralHub.Api.Tests/MeasurementControllerTests.cs
@@ -46,7 +46,8 @@ public class MeasurementControllerTests
         _aggregatedMeasurementRepository = new MockAggregatedMeasurementRepository();
         _measurementController = new MeasurementController(
             NullLogger<MeasurementController>.Instance,
-            _aggregatedMeasurementRepository);
+            _aggregatedMeasurementRepository,
+            _trackerRepository);
     }
 
     [TearDown]
@@ -63,8 +64,8 @@ public class MeasurementControllerTests
     public async Task TestAddMeasurements()
     {
         var measurements = new Measurement[] {
-            new Measurement("11:22:33:44:55:66", Measurement.Protocol.Bluetooth, 10),
-            new Measurement("aa:bb:cc:dd:ee:ff", Measurement.Protocol.Wifi, 20)
+            new Measurement("22:22:33:44:55:66", Measurement.Protocol.Bluetooth, 10),
+            new Measurement("bb:bb:cc:dd:ee:ff", Measurement.Protocol.Wifi, 20)
         };
 
         var addMeasurementsRequest = new AddMeasurementsRequest(_trackerId, measurements);
@@ -74,5 +75,20 @@ public class MeasurementControllerTests
         Assert.That(addedMeasurements, Has.Count.EqualTo(measurements.Length));
         Assert.That(addedMeasurements, Does.Contain(measurements[0]));
         Assert.That(addedMeasurements, Does.Contain(measurements[1]));
+    }
+
+    [Test]
+    public async Task TestAddTrackerAsMeasurements()
+    {
+        var measurements = new Measurement[] {
+            new Measurement("11:22:33:44:55:66", Measurement.Protocol.Bluetooth, 10),
+            new Measurement("aa:bb:cc:dd:ee:ff", Measurement.Protocol.Wifi, 20)
+        };
+
+        var addMeasurementsRequest = new AddMeasurementsRequest(_trackerId, measurements);
+        await _measurementController.AddMeasurements(addMeasurementsRequest, default);
+        var addedMeasurements = (await _aggregatedMeasurementRepository.GetTrackerMeasurementGroupsAsync(default))[_trackerId][0].Measurements;
+
+        Assert.That(addedMeasurements, Has.Count.EqualTo(0));
     }
 }

--- a/CentralHub.Api.Tests/MockAggregatedMeasurementRepository.cs
+++ b/CentralHub.Api.Tests/MockAggregatedMeasurementRepository.cs
@@ -54,7 +54,7 @@ internal sealed class MockAggregatedMeasurementRepository : IMeasurementReposito
         }
     }
 
-    public async Task<IReadOnlyDictionary<int, IReadOnlyList<MeasurementGroup>>> GetTrackerMeasurementGroupsAsync(CancellationToken cancellationToken)
+    public async Task<IReadOnlyDictionary<int, IReadOnlyList<MeasurementGroup>>> GetRoomMeasurementGroupsAsync(CancellationToken cancellationToken)
     {
         return await Task.Run(() =>
         {

--- a/CentralHub.Api.Tests/MockTrackerRepository.cs
+++ b/CentralHub.Api.Tests/MockTrackerRepository.cs
@@ -89,6 +89,6 @@ internal sealed class MockTrackerRepository : ITrackerRepository
 
     public Task<IEnumerable<TrackerDto>> GetRegisteredTrackers(CancellationToken cancellationToken)
     {
-        return Task.FromResult(RoomDto.Trackers.AsEnumerable());
+        return Task.FromResult(RoomDto.Trackers.ToList().AsEnumerable());
     }
 }

--- a/CentralHub.Api.Tests/MockTrackerRepository.cs
+++ b/CentralHub.Api.Tests/MockTrackerRepository.cs
@@ -86,4 +86,9 @@ internal sealed class MockTrackerRepository : ITrackerRepository
             });
         return Task.CompletedTask;
     }
+
+    public Task<IEnumerable<TrackerDto>> GetRegisteredTrackers(CancellationToken cancellationToken)
+    {
+        return Task.FromResult(RoomDto.Trackers.AsEnumerable());
+    }
 }

--- a/CentralHub.Api.Tests/ServiceTests.cs
+++ b/CentralHub.Api.Tests/ServiceTests.cs
@@ -15,8 +15,6 @@ class ServiceTests
 
     private int _roomId = 0;
 
-    private int _trackerId = 0;
-
     private LocalizationService _localizationService;
 
     [SetUp]
@@ -41,14 +39,13 @@ class ServiceTests
             RoomDto = roomDto
         };
         _trackerRepository = new MockTrackerRepository(roomDto);
-        _trackerId = _trackerRepository.AddTrackerAsync(trackerDto, default).GetAwaiter().GetResult();
+        _trackerRepository.AddTrackerAsync(trackerDto, default).GetAwaiter().GetResult();
 
         _aggregatedMeasurementRepository = new MockAggregatedMeasurementRepository();
         _localizationService = new LocalizationService(
             NullLogger<LocalizationService>.Instance,
             _aggregatedMeasurementRepository,
-            _roomRepository,
-            _trackerRepository);
+            _roomRepository);
     }
 
     [TearDown]
@@ -64,13 +61,13 @@ class ServiceTests
     [Test]
     public async Task TestAggregateSingleGroupMeasurements()
     {
-        await _aggregatedMeasurementRepository.AddMeasurementsAsync(_trackerId, new List<Measurement>(){
+        await _aggregatedMeasurementRepository.AddMeasurementsAsync(_roomId, new List<Measurement>(){
             new Measurement("11:22:33:44:55:66", Measurement.Protocol.Wifi, -40),
             new Measurement("11:22:33:44:55:66", Measurement.Protocol.Bluetooth, -10),
         }, default);
 
         await _localizationService.AggregateMeasurementsAsync(default);
-        Assert.That(await _aggregatedMeasurementRepository.GetTrackerMeasurementGroupsAsync(default), Is.Empty);
+        Assert.That(await _aggregatedMeasurementRepository.GetRoomMeasurementGroupsAsync(default), Is.Empty);
 
         var aggregatedMeasurements = await _aggregatedMeasurementRepository.GetAggregatedMeasurementsAsync(_roomId, default);
 
@@ -94,14 +91,14 @@ class ServiceTests
     [Test]
     public async Task TestAggregateMultipleGroupsOfMeasurements()
     {
-        await _aggregatedMeasurementRepository.AddMeasurementsAsync(_trackerId, new List<Measurement>(){
+        await _aggregatedMeasurementRepository.AddMeasurementsAsync(_roomId, new List<Measurement>(){
             new Measurement("11:22:33:44:55:66", Measurement.Protocol.Wifi, -40),
             new Measurement("11:22:33:44:55:66", Measurement.Protocol.Bluetooth, -10),
             new Measurement("21:22:33:44:55:66", Measurement.Protocol.Wifi, -40),
             new Measurement("21:22:33:44:55:66", Measurement.Protocol.Bluetooth, -10),
         }, default);
 
-        await _aggregatedMeasurementRepository.AddMeasurementsAsync(_trackerId, new List<Measurement>(){
+        await _aggregatedMeasurementRepository.AddMeasurementsAsync(_roomId, new List<Measurement>(){
             new Measurement("31:22:33:44:55:66", Measurement.Protocol.Wifi, -40),
             new Measurement("41:22:33:44:55:66", Measurement.Protocol.Bluetooth, -10),
             new Measurement("51:22:33:44:55:66", Measurement.Protocol.Wifi, -40),
@@ -111,7 +108,7 @@ class ServiceTests
         }, default);
 
         await _localizationService.AggregateMeasurementsAsync(default);
-        Assert.That(await _aggregatedMeasurementRepository.GetTrackerMeasurementGroupsAsync(default), Is.Empty);
+        Assert.That(await _aggregatedMeasurementRepository.GetRoomMeasurementGroupsAsync(default), Is.Empty);
 
         var aggregatedMeasurements = await _aggregatedMeasurementRepository.GetAggregatedMeasurementsAsync(_roomId, default);
 
@@ -135,7 +132,7 @@ class ServiceTests
     [Test]
     public async Task TestAggregateDuplicateMeasurements()
     {
-        await _aggregatedMeasurementRepository.AddMeasurementsAsync(_trackerId, new List<Measurement>(){
+        await _aggregatedMeasurementRepository.AddMeasurementsAsync(_roomId, new List<Measurement>(){
             new Measurement("11:22:33:44:55:66", Measurement.Protocol.Wifi, -40),
             new Measurement("11:22:33:44:55:66", Measurement.Protocol.Wifi, -10),
             new Measurement("11:22:33:44:55:66", Measurement.Protocol.Bluetooth, -40),
@@ -143,7 +140,7 @@ class ServiceTests
         }, default);
 
         await _localizationService.AggregateMeasurementsAsync(default);
-        Assert.That(await _aggregatedMeasurementRepository.GetTrackerMeasurementGroupsAsync(default), Is.Empty);
+        Assert.That(await _aggregatedMeasurementRepository.GetRoomMeasurementGroupsAsync(default), Is.Empty);
 
         var aggregatedMeasurements = await _aggregatedMeasurementRepository.GetAggregatedMeasurementsAsync(_roomId, default);
 
@@ -160,7 +157,7 @@ class ServiceTests
     public async Task TestNoMeasurements()
     {
         await _localizationService.AggregateMeasurementsAsync(default);
-        Assert.That(await _aggregatedMeasurementRepository.GetTrackerMeasurementGroupsAsync(default), Is.Empty);
+        Assert.That(await _aggregatedMeasurementRepository.GetRoomMeasurementGroupsAsync(default), Is.Empty);
 
         var aggregatedMeasurements = await _aggregatedMeasurementRepository.GetAggregatedMeasurementsAsync(_roomId, default);
 

--- a/CentralHub.Api.Tests/ServiceTests.cs
+++ b/CentralHub.Api.Tests/ServiceTests.cs
@@ -35,8 +35,8 @@ class ServiceTests
         {
             Name = "Test Tracker",
             Description = "Test Tracker",
-            BluetoothMacAddress = "11:22:33:44:55:66",
-            WifiMacAddress = "aa:bb:cc:dd:ee:ff",
+            BluetoothMacAddress = "ff:22:33:44:55:66",
+            WifiMacAddress = "ff:bb:cc:dd:ee:ff",
             RoomDtoId = roomDto.RoomDtoId,
             RoomDto = roomDto
         };
@@ -154,5 +154,30 @@ class ServiceTests
         Assert.That(aggregatedMeasurement.MeasurementGroupCount, Is.EqualTo(1));
         Assert.That(aggregatedMeasurement.TotalBluetoothDeviceCount, Is.EqualTo(1));
         Assert.That(aggregatedMeasurement.TotalWifiDeviceCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task TestNoMeasurements()
+    {
+        await _localizationService.AggregateMeasurementsAsync(default);
+        Assert.That(await _aggregatedMeasurementRepository.GetTrackerMeasurementGroupsAsync(default), Is.Empty);
+
+        var aggregatedMeasurements = await _aggregatedMeasurementRepository.GetAggregatedMeasurementsAsync(_roomId, default);
+
+        Assert.That(aggregatedMeasurements, Has.Exactly(1).Items);
+
+        var aggregatedMeasurement = aggregatedMeasurements.First();
+
+        Assert.That(aggregatedMeasurement.MeasurementGroupCount, Is.EqualTo(1));
+        Assert.That(aggregatedMeasurement.BluetoothMedianDeviceCount, Is.EqualTo(0));
+        Assert.That(aggregatedMeasurement.WifiMedianDeviceCount, Is.EqualTo(0));
+        Assert.That(aggregatedMeasurement.BluetoothMeanDeviceCount, Is.EqualTo(0));
+        Assert.That(aggregatedMeasurement.WifiMeanDeviceCount, Is.EqualTo(0));
+        Assert.That(aggregatedMeasurement.BluetoothMaxDeviceCount, Is.EqualTo(0));
+        Assert.That(aggregatedMeasurement.WifiMaxDeviceCount, Is.EqualTo(0));
+        Assert.That(aggregatedMeasurement.BluetoothMinDeviceCount, Is.EqualTo(0));
+        Assert.That(aggregatedMeasurement.WifiMinDeviceCount, Is.EqualTo(0));
+        Assert.That(aggregatedMeasurement.TotalBluetoothDeviceCount, Is.EqualTo(0));
+        Assert.That(aggregatedMeasurement.TotalWifiDeviceCount, Is.EqualTo(0));
     }
 }

--- a/CentralHub.Api/Services/IMeasurementRepository.cs
+++ b/CentralHub.Api/Services/IMeasurementRepository.cs
@@ -13,7 +13,7 @@ public interface IMeasurementRepository
 
     Task<IEnumerable<AggregatedMeasurementDto>> GetAggregatedMeasurementsAsync(int roomId, DateTime timeStart, DateTime timeEnd, CancellationToken cancellationToken);
 
-    Task<IReadOnlyDictionary<int, IReadOnlyList<MeasurementGroup>>> GetTrackerMeasurementGroupsAsync(CancellationToken cancellationToken);
+    Task<IReadOnlyDictionary<int, IReadOnlyList<MeasurementGroup>>> GetRoomMeasurementGroupsAsync(CancellationToken cancellationToken);
 
-    Task AddMeasurementsAsync(int trackerId, IReadOnlyCollection<Measurement> measurements, CancellationToken cancellationToken);
+    Task AddMeasurementsAsync(int roomId, IReadOnlyCollection<Measurement> measurements, CancellationToken cancellationToken);
 }

--- a/CentralHub.Api/Services/ITrackerRepository.cs
+++ b/CentralHub.Api/Services/ITrackerRepository.cs
@@ -17,6 +17,8 @@ public interface ITrackerRepository
     Task<TrackerDto?> GetTrackerByMacAddresses(string wifiMacAddress, string bluetoothMacAddress,
         CancellationToken cancellationToken);
 
+    Task<IEnumerable<TrackerDto>> GetRegisteredTrackers(CancellationToken cancellationToken);
+
     Task<IEnumerable<UnregisteredTrackerDto>> GetUnregisteredTrackers(CancellationToken cancellationToken);
 
     Task AddUnregisteredTracker(string wifiMacAddress, string bluetoothMacAddress, CancellationToken cancellationToken);

--- a/CentralHub.Api/Services/LocalizationService.cs
+++ b/CentralHub.Api/Services/LocalizationService.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using App.ScopedService;
 using CentralHub.Api.Dtos;
 using CentralHub.Api.Model;
+using CentralHub.Api.Model.Responses.Room;
 
 namespace CentralHub.Api.Services;
 
@@ -41,6 +42,7 @@ public class LocalizationService : IScopedProcessingService
     public async Task AggregateMeasurementsAsync(CancellationToken stoppingToken)
     {
         var trackerMeasurementGroups = await _aggregatorRepository.GetTrackerMeasurementGroupsAsync(stoppingToken);
+        var measuredRooms = new List<RoomDto>();
 
         foreach (var (trackerId, measurementGroups) in trackerMeasurementGroups)
         {
@@ -63,9 +65,19 @@ public class LocalizationService : IScopedProcessingService
                 _logger.LogWarning("Room with id {RoomId} was not found.", tracker.RoomDtoId);
                 continue;
             }
+            measuredRooms.Add(room);
 
             await _aggregatorRepository.AddAggregatedMeasurementAsync(
                 CreateAggregatedMeasurement(room, measurementGroups),
+                stoppingToken);
+        }
+
+        var allRooms = await _roomRepository.GetRoomsAsync(stoppingToken);
+
+        foreach (var room in allRooms.Where(r => !measuredRooms.Contains(r)))
+        {
+            await _aggregatorRepository.AddAggregatedMeasurementAsync(
+                CreateAggregatedMeasurement(room, new List<MeasurementGroup>()),
                 stoppingToken);
         }
     }
@@ -75,16 +87,17 @@ public class LocalizationService : IScopedProcessingService
         var measurements = measurementGroups.SelectMany(mg => mg.Measurements);
         var bluetooth = measurements.Where(m => m.Type == Measurement.Protocol.Bluetooth);
         var wifi = measurements.Where(m => m.Type == Measurement.Protocol.Wifi);
+        var now = DateTime.Now;
 
-        var startMeasurementTime = measurementGroups.Min(mg => mg.Timestamp);
-        var endMeasurementTime = measurementGroups.Max(mg => mg.Timestamp);
+        var startMeasurementTime = measurementGroups.Count == 0 ? measurementGroups.Min(mg => mg.Timestamp) : now - _sleepTime;
+        var endMeasurementTime = measurementGroups.Count == 0 ? measurementGroups.Max(mg => mg.Timestamp) : now;
 
         var filteredMeasurementsGroups = measurementGroups.Select(mg => FilterMeasurements(mg.Measurements)).ToImmutableArray();
         var numBluetoothPerGroup = filteredMeasurementsGroups.Select(m => m.Count(m => m.Type == Measurement.Protocol.Bluetooth)).ToImmutableArray();
         var numWifiPerGroup = filteredMeasurementsGroups.Select(m => m.Count(m => m.Type == Measurement.Protocol.Wifi)).ToImmutableArray();
 
 
-        var measurementCount = measurementGroups.Count;
+        var measurementGroupCount = measurementGroups.Count == 0 ? measurementGroups.Count : 1;
 
         var bluetoothMax = MaxDevices(numBluetoothPerGroup);
 
@@ -114,7 +127,7 @@ public class LocalizationService : IScopedProcessingService
         {
             StartTime = startMeasurementTime,
             EndTime = endMeasurementTime,
-            MeasurementGroupCount = measurementCount,
+            MeasurementGroupCount = measurementGroupCount,
             BluetoothMaxDeviceCount = bluetoothMax,
             BluetoothMedianDeviceCount = bluetoothMedian,
             BluetoothMeanDeviceCount = bluetoothMean,

--- a/CentralHub.Api/Services/MeasurementRepository.cs
+++ b/CentralHub.Api/Services/MeasurementRepository.cs
@@ -8,7 +8,7 @@ namespace CentralHub.Api.Services;
 
 internal sealed class MeasurementRepository : IMeasurementRepository
 {
-    private readonly static Dictionary<int, List<MeasurementGroup>> _recentTrackerMeasurementGroups = new Dictionary<int, List<MeasurementGroup>>();
+    private readonly static Dictionary<int, List<MeasurementGroup>> _recentRoomMeasurementGroups = new Dictionary<int, List<MeasurementGroup>>();
 
     private readonly ApplicationDbContext _applicationDbContext;
 
@@ -63,35 +63,35 @@ internal sealed class MeasurementRepository : IMeasurementRepository
             .ToArrayAsync(cancellationToken);
     }
 
-    public async Task AddMeasurementsAsync(int trackerId, IReadOnlyCollection<Measurement> measurements, CancellationToken cancellationToken)
+    public async Task AddMeasurementsAsync(int roomId, IReadOnlyCollection<Measurement> measurements, CancellationToken cancellationToken)
     {
         await Task.Run(() =>
         {
-            lock (_recentTrackerMeasurementGroups)
+            lock (_recentRoomMeasurementGroups)
             {
-                if (_recentTrackerMeasurementGroups.TryGetValue(trackerId, out var value))
+                if (_recentRoomMeasurementGroups.TryGetValue(roomId, out var value))
                 {
                     value.Add(new MeasurementGroup(measurements.ToImmutableArray()));
                 }
                 else
                 {
-                    _recentTrackerMeasurementGroups.Add(trackerId, new List<MeasurementGroup>() { new MeasurementGroup(measurements.ToImmutableArray()) });
+                    _recentRoomMeasurementGroups.Add(roomId, new List<MeasurementGroup>() { new MeasurementGroup(measurements.ToImmutableArray()) });
                 }
             }
         }, cancellationToken);
     }
 
-    public async Task<IReadOnlyDictionary<int, IReadOnlyList<MeasurementGroup>>> GetTrackerMeasurementGroupsAsync(CancellationToken cancellationToken)
+    public async Task<IReadOnlyDictionary<int, IReadOnlyList<MeasurementGroup>>> GetRoomMeasurementGroupsAsync(CancellationToken cancellationToken)
     {
         return await Task.Run(() =>
         {
-            lock (_recentTrackerMeasurementGroups)
+            lock (_recentRoomMeasurementGroups)
             {
-                var recentTrackerMeasurementGroups = _recentTrackerMeasurementGroups
+                var recentRoomMeasurementGroups = _recentRoomMeasurementGroups
                     .ToDictionary(kvp => kvp.Key, kvp => (IReadOnlyList<MeasurementGroup>)kvp.Value.ToImmutableArray());
 
-                _recentTrackerMeasurementGroups.Clear();
-                return recentTrackerMeasurementGroups;
+                _recentRoomMeasurementGroups.Clear();
+                return recentRoomMeasurementGroups;
             }
         }, cancellationToken);
     }

--- a/CentralHub.Api/Services/SampleTrackerRepository.cs
+++ b/CentralHub.Api/Services/SampleTrackerRepository.cs
@@ -147,4 +147,12 @@ public sealed class SampleTrackerRepository : ITrackerRepository
                 });
         }, cancellationToken);
     }
+
+    public async Task<IEnumerable<TrackerDto>> GetRegisteredTrackers(CancellationToken cancellationToken)
+    {
+        return await LockedStuffMutex.Lock(stuff =>
+        {
+            return stuff.Trackers.Values.ToImmutableArray();
+        }, cancellationToken);
+    }
 }

--- a/CentralHub.Api/Services/TrackerRepository.cs
+++ b/CentralHub.Api/Services/TrackerRepository.cs
@@ -159,6 +159,14 @@ public sealed class TrackerRepository : ITrackerRepository
         return tracker;
     }
 
+    public async Task<IEnumerable<TrackerDto>> GetRegisteredTrackers(CancellationToken cancellationToken)
+    {
+        return await _applicationDbContext.Rooms
+            .Include(r => r.Trackers)
+            .SelectMany(r => r.Trackers)
+            .ToArrayAsync(cancellationToken);
+    }
+
     public async Task<IEnumerable<UnregisteredTrackerDto>> GetUnregisteredTrackers(CancellationToken cancellationToken)
     {
         return await UnregisteredTrackersMutex.Lock(unregisteredTrackers =>


### PR DESCRIPTION
Filter trackers mac adresses, so they are not part of the measurements.
Fixed an issue with empty measurements not being stored properly.
Added some more tests.